### PR TITLE
Add vmagic maven repo to project.clj. 

### DIFF
--- a/components/misc/fpga_reboot.vhm
+++ b/components/misc/fpga_reboot.vhm
@@ -105,41 +105,6 @@ begin
       write => this'register.step.write);
 end architecture;
 
-library ieee;
-use ieee.std_logic_1164.all;
-use ieee.numeric_std.all;
-
-library unisim;
-use unisim.vcomponents.all;
-
-entity fpga_reboot is
-  generic (
-    RESYNC_EN : boolean := false);
-  port (
-    clk : in std_logic;
-    rst : in std_logic;
-    en  : in std_logic);
-
-  -- The order of bits in documented commands and the bits in the CAP entity
-  -- data ports is strange. Each byte is reversed. See "SelectMAP Data
-  -- Ordering" in UG380 http://www.xilinx.com/support/documentation/user_guides/ug380.pdf
-  function reorderdata(data : std_logic_vector(7 downto 0))
-    return std_logic_vector is
-    variable pins : std_logic_vector(7 downto 0);
-  begin
-    pins( 7) := data( 0);
-    pins( 6) := data( 1);
-    pins( 5) := data( 2);
-    pins( 4) := data( 3);
-
-    pins( 3) := data( 4);
-    pins( 2) := data( 5);
-    pins( 1) := data( 6);
-    pins( 0) := data( 7);
-    return pins;
-  end function;
-end entity;
-
 architecture k7 of fpga_reboot is
   type step_t is record
     ce : std_logic;

--- a/targets/soc_gen/project.clj
+++ b/targets/soc_gen/project.clj
@@ -1,4 +1,5 @@
 (defproject soc_gen "0.1.0-SNAPSHOT"
+  :repositories {"vmagic repo" "https://maven.pshdl.org/"}
   :description ""
   :dependencies [[org.clojure/clojure "1.6.0"]
                  [org.clojure/core.match "0.2.2"]
@@ -8,10 +9,10 @@
                  [org.clojure/tools.cli "0.3.1"]
                  [watchtower "0.1.1"]
                  [com.stuartsierra/dependency "0.1.1"]
-                 [rkworks/baum "0.1.2"]]
+                 [rkworks/baum "0.1.2"]
+		 [de.upb.hni.vmagic/vmagic "0.4-SNAPSHOT"]
+		 [de.upb.hni.vmagic/vmagic-parser "0.4-SNAPSHOT"]]
   :java-source-paths ["lib/logic"]
-  :resource-paths ["lib/vmagic-0.4-SNAPSHOT.jar"
-                   "lib/vmagic-parser-0.4-SNAPSHOT.jar"]
   :main ^:skip-aot soc-gen.main
   :target-path "target/%s"
   :profiles {:uberjar {:aot :all}})


### PR DESCRIPTION
Automatically fetches vmagic-parser and vmagic which are missing within the repository.

(The default setup only creates two empty folders within soc_gen/lib and fails)